### PR TITLE
refactor: extract feature handlers

### DIFF
--- a/src/content/approveHandler.ts
+++ b/src/content/approveHandler.ts
@@ -1,0 +1,76 @@
+import { ShowSettings } from './showSettings';
+import { isPullRequestPage } from './pageUtils';
+
+export interface ApprovalSuccessOptions {
+  showSettings: ShowSettings;
+  onApproved: () => void;
+}
+
+export interface ApprovalButtonOptions {
+  showSettings: ShowSettings;
+}
+
+export const checkForPRApprovalSuccess = (options: ApprovalSuccessOptions): void => {
+  if (!isPullRequestPage()) return;
+
+  chrome.storage.local.get(['prApprovalTriggered', 'prApprovalTime'], (result) => {
+    if (result.prApprovalTriggered && result.prApprovalTime) {
+      const timeDiff = Date.now() - result.prApprovalTime;
+      if (timeDiff < 30000 && options.showSettings.isEnabled('approved')) {
+        console.log('✅ PR approval detected via storage flag, showing banner');
+        options.onApproved();
+        chrome.storage.local.remove(['prApprovalTriggered', 'prApprovalTime']);
+      } else if (timeDiff < 30000 && !options.showSettings.isEnabled('approved')) {
+        console.log('🚫 PR approval detected but disabled in settings');
+        chrome.storage.local.remove(['prApprovalTriggered', 'prApprovalTime']);
+      }
+    }
+  });
+};
+
+export const detectPRApprovalButtons = (options: ApprovalButtonOptions): void => {
+  if (!isPullRequestPage()) {
+    return;
+  }
+
+  const dialogElement = document.querySelector('div[role="dialog"]');
+  if (dialogElement) {
+    const buttons = Array.from(dialogElement.querySelectorAll('button'));
+    const submitButton = buttons.find((button) =>
+      button.textContent?.toLowerCase().includes('submit review'),
+    );
+
+    if (submitButton && !submitButton.hasAttribute('data-elden-ring-approval-listener')) {
+      submitButton.addEventListener('click', () => {
+        const approveRadio = dialogElement.querySelector(
+          'input[name="reviewEvent"][value="approve"]',
+        ) as HTMLInputElement;
+
+        if (approveRadio && approveRadio.checked) {
+          if (options.showSettings.isEnabled('approved')) {
+            console.log('🎯 Submit review with approval selected');
+            chrome.storage.local.set({
+              prApprovalTriggered: true,
+              prApprovalTime: Date.now(),
+            });
+          } else {
+            console.log('🚫 PR approval banner disabled in settings');
+          }
+        }
+      });
+      submitButton.setAttribute('data-elden-ring-approval-listener', 'true');
+    }
+  }
+
+  const approveRadios = document.querySelectorAll('input[name="reviewEvent"][value="approve"]');
+  approveRadios.forEach((radio) => {
+    if (!radio.hasAttribute('data-elden-ring-approval-listener')) {
+      radio.addEventListener('change', () => {
+        if ((radio as HTMLInputElement).checked) {
+          console.log('🎯 Approve option selected');
+        }
+      });
+      radio.setAttribute('data-elden-ring-approval-listener', 'true');
+    }
+  });
+};

--- a/src/content/closeHandler.ts
+++ b/src/content/closeHandler.ts
@@ -1,0 +1,34 @@
+import { ShowSettings } from './showSettings';
+import { isPullRequestPage } from './pageUtils';
+import { waitForCloseComplete } from './closeWatcher';
+
+export interface CloseHandlerOptions {
+  showSettings: ShowSettings;
+  onClosed: () => void;
+}
+
+export const detectCloseButtons = (options: CloseHandlerOptions): void => {
+  if (!isPullRequestPage() || !options.showSettings.isEnabled('closed')) {
+    return;
+  }
+
+  const closeButtonContainer = document.querySelector('#partial-new-comment-form-actions');
+  if (!closeButtonContainer) {
+    return;
+  }
+
+  const closeButtons = closeButtonContainer.querySelectorAll('button');
+  closeButtons.forEach((button) => {
+    const buttonText = button.textContent?.toLowerCase().trim() || '';
+    if (
+      buttonText.includes('close pull request') &&
+      !button.hasAttribute('data-elden-ring-close-listener')
+    ) {
+      button.addEventListener('click', () => {
+        console.log('🛑 Close pull request button clicked');
+        waitForCloseComplete(() => options.onClosed());
+      });
+      button.setAttribute('data-elden-ring-close-listener', 'true');
+    }
+  });
+};

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-describe('EldenRingMerger', () => {
+describe('EldenRingOrchestrator', () => {
   it('should call storage API for loading settings', () => {
     // Simulate the loadSettings method behavior
     chrome.storage.sync.get(['soundEnabled', 'showOnPRMerged', 'showOnPRCreate'], () => {});

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,19 +1,28 @@
 import { renderBanner, type BannerType } from './banner';
-import { waitForCloseComplete } from './closeWatcher';
+import {
+  MergeFeature,
+  CreationFeature,
+  ApprovalFeature,
+  CloseFeature,
+  type GitHubFeature,
+} from './features';
+import { ShowSettings } from './showSettings';
+import { SettingsStore, type SettingsState } from './settingsStore';
 
-class EldenRingMerger {
+class EldenRingOrchestrator {
   private bannerShown: boolean = false;
   private soundEnabled: boolean = true;
-  private showOnPRMerged: boolean = true;
-  private showOnPRCreate: boolean = true;
-  private showOnPRApprove: boolean = true;
-  private showOnPRClose: boolean = true;
   private soundType: 'you-die-sound' | 'lost-grace-discovered' = 'you-die-sound';
   private soundUrl: string;
+  private features: GitHubFeature[] = [];
+  private settingsStore = new SettingsStore();
+  private showSettings = new ShowSettings(() => this.settingsStore.getState());
 
   constructor() {
     this.soundUrl = this.getSoundUrl();
-    this.loadSettings();
+    this.subscribeToSettings();
+    this.settingsStore.init();
+    this.features = this.createFeatures();
     this.init();
   }
 
@@ -25,161 +34,34 @@ class EldenRingMerger {
     this.soundUrl = this.getSoundUrl();
   }
 
-  private loadSettings(): void {
-    chrome.storage.sync.get(
-      [
-        'soundEnabled',
-        'showOnPRMerged',
-        'showOnPRCreate',
-        'showOnPRApprove',
-        'showOnPRClose',
-        'soundType',
-      ],
-      (result: {
-        soundEnabled?: boolean;
-        showOnPRMerged?: boolean;
-        showOnPRCreate?: boolean;
-        showOnPRApprove?: boolean;
-        showOnPRClose?: boolean;
-        soundType?: 'you-die-sound' | 'lost-grace-discovered';
-      }) => {
-        this.soundEnabled = result.soundEnabled !== false; // default true
-        this.showOnPRMerged = result.showOnPRMerged !== false; // default true
-        this.showOnPRCreate = result.showOnPRCreate !== false; // default true
-        this.showOnPRApprove = result.showOnPRApprove !== false; // default true
-        this.showOnPRClose = result.showOnPRClose !== false; // default true
-        this.soundType = result.soundType || 'you-die-sound'; // default you-die-sound
-        this.updateSoundUrl();
-      },
-    );
+  private subscribeToSettings(): void {
+    this.settingsStore.subscribe((state) => this.applySettings(state));
+  }
 
-    // Listen for settings changes
-    chrome.storage.onChanged.addListener(
-      (changes: { [key: string]: chrome.storage.StorageChange }) => {
-        if (changes.soundEnabled) {
-          this.soundEnabled = changes.soundEnabled.newValue;
-        }
-        if (changes.showOnPRMerged) {
-          this.showOnPRMerged = changes.showOnPRMerged.newValue;
-        }
-        if (changes.showOnPRCreate) {
-          this.showOnPRCreate = changes.showOnPRCreate.newValue;
-        }
-        if (changes.showOnPRApprove) {
-          this.showOnPRApprove = changes.showOnPRApprove.newValue;
-        }
-        if (changes.showOnPRClose) {
-          this.showOnPRClose = changes.showOnPRClose.newValue;
-        }
-        if (changes.soundType) {
-          this.soundType = changes.soundType.newValue;
-          this.updateSoundUrl();
-        }
-      },
-    );
+  private applySettings(state: SettingsState): void {
+    this.soundEnabled = state.soundEnabled;
+    this.soundType = state.soundType;
+    this.updateSoundUrl();
   }
 
   private init(): void {
     // Wait for page to load
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', () => this.setupMergeDetection());
+      document.addEventListener('DOMContentLoaded', () => this.initializeFeatures());
     } else {
-      this.setupMergeDetection();
+      this.initializeFeatures();
     }
   }
 
-  private setupMergeDetection(): void {
-    // Check if we just created a PR and should show banner
-    this.checkForPRCreationSuccess();
-
-    // Check if we just approved a PR and should show banner
-    this.checkForPRApprovalSuccess();
-
-    // Detect merge button clicks
-    this.detectMergeButtons();
-
-    // Detect close button clicks
-    this.detectCloseButtons();
-
-    // Detect PR creation button clicks
-    this.detectPRCreationButtons();
-
-    // Detect PR approval button clicks
-    this.detectPRApprovalButtons();
-
-    // Observe DOM changes for dynamically loaded content
+  private initializeFeatures(): void {
+    this.features.forEach((feature) => feature.initialize());
     this.observeDOMChanges();
-  }
-
-  private detectMergeButtons(): void {
-    // First check if we're on a PR page
-    const currentUrl = window.location.href;
-    const isPRPage = /\/pull\/\d+/.test(currentUrl);
-    if (!isPRPage) {
-      return;
-    }
-
-    // Look for buttons with merge text in .merge-pr container
-    const mergePrContainer = document.querySelector('.merge-pr');
-    if (mergePrContainer) {
-      const buttons = mergePrContainer.querySelectorAll('button');
-      buttons.forEach((button) => {
-        const buttonText = button.textContent?.toLowerCase().trim() || '';
-        const specificMergeTexts = [
-          'confirm merge',
-          'confirm squash and merge',
-          'confirm rebase and merge',
-        ];
-
-        if (
-          specificMergeTexts.some((text) => buttonText.includes(text)) &&
-          !button.hasAttribute('data-elden-ring-listener')
-        ) {
-          button.addEventListener('click', () => {
-            console.log('🎯 Merge button clicked:', buttonText);
-            this.waitForMergeComplete();
-          });
-          button.setAttribute('data-elden-ring-listener', 'true');
-        }
-      });
-    }
-  }
-
-  private detectCloseButtons(): void {
-    const currentUrl = window.location.href;
-    const isPRPage = /\/pull\/\d+/.test(currentUrl);
-    if (!isPRPage || !this.showOnPRClose) {
-      return;
-    }
-
-    const closeButtonContainer = document.querySelector('#partial-new-comment-form-actions');
-    if (!closeButtonContainer) {
-      return;
-    }
-
-    const closeButtons = closeButtonContainer.querySelectorAll('button');
-    closeButtons.forEach((button) => {
-      const buttonText = button.textContent?.toLowerCase().trim() || '';
-      if (
-        buttonText.includes('close pull request') &&
-        !button.hasAttribute('data-elden-ring-close-listener')
-      ) {
-        button.addEventListener('click', () => {
-          console.log('🛑 Close pull request button clicked');
-          waitForCloseComplete(() => this.handleCloseCelebration());
-        });
-        button.setAttribute('data-elden-ring-close-listener', 'true');
-      }
-    });
   }
 
   private observeDOMChanges(): void {
     // Observe for GitHub's dynamic content loading
     const observer = new MutationObserver(() => {
-      this.detectMergeButtons();
-      this.detectCloseButtons();
-      this.detectPRCreationButtons();
-      this.detectPRApprovalButtons();
+      this.features.forEach((feature) => feature.onDomChange());
     });
 
     observer.observe(document.body, {
@@ -188,192 +70,7 @@ class EldenRingMerger {
     });
   }
 
-  private checkForPRCreationSuccess(): void {
-    // Check if we're on a PR page and if creation was recently triggered
-    const currentUrl = window.location.href;
-    const isPRPage = /\/pull\/\d+/.test(currentUrl);
-
-    if (!isPRPage) return;
-
-    chrome.storage.local.get(['prCreationTriggered', 'prCreationTime'], (result) => {
-      if (result.prCreationTriggered && result.prCreationTime) {
-        const timeDiff = Date.now() - result.prCreationTime;
-        // If the PR was created within the last 30 seconds and the setting is enabled, show banner
-        if (timeDiff < 30000 && this.showOnPRCreate) {
-          console.log('✅ PR creation detected via storage flag, showing banner');
-          this.showEldenRingBanner('created');
-
-          // Clear the flag so we don't show banner again
-          chrome.storage.local.remove(['prCreationTriggered', 'prCreationTime']);
-        } else if (timeDiff < 30000 && !this.showOnPRCreate) {
-          console.log('🚫 PR creation detected but disabled in settings');
-          // Still clear the flag even if disabled
-          chrome.storage.local.remove(['prCreationTriggered', 'prCreationTime']);
-        }
-      }
-    });
-  }
-
-  private checkForPRApprovalSuccess(): void {
-    // Check if we're on a PR page and if approval was recently triggered
-    const currentUrl = window.location.href;
-    const isPRPage = /\/pull\/\d+/.test(currentUrl);
-
-    if (!isPRPage) return;
-
-    chrome.storage.local.get(['prApprovalTriggered', 'prApprovalTime'], (result) => {
-      if (result.prApprovalTriggered && result.prApprovalTime) {
-        const timeDiff = Date.now() - result.prApprovalTime;
-        // If the PR was approved within the last 30 seconds and the setting is enabled, show banner
-        if (timeDiff < 30000 && this.showOnPRApprove) {
-          console.log('✅ PR approval detected via storage flag, showing banner');
-          this.showEldenRingBanner('approved');
-
-          // Clear the flag so we don't show banner again
-          chrome.storage.local.remove(['prApprovalTriggered', 'prApprovalTime']);
-        } else if (timeDiff < 30000 && !this.showOnPRApprove) {
-          console.log('🚫 PR approval detected but disabled in settings');
-          // Still clear the flag even if disabled
-          chrome.storage.local.remove(['prApprovalTriggered', 'prApprovalTime']);
-        }
-      }
-    });
-  }
-
-  private detectPRCreationButtons(): void {
-    // Check if we're on a compare page
-    const currentUrl = window.location.href;
-    const isComparePage = /\/compare/.test(currentUrl);
-    if (!isComparePage) {
-      return;
-    }
-
-    // Look for "Create pull request" button using GitHub's specific selector
-    const createButton = document.querySelector('.hx_create-pr-button');
-    if (createButton && !createButton.hasAttribute('data-elden-ring-listener')) {
-      createButton.addEventListener('click', () => {
-        console.log('🎯 Create pull request button clicked');
-        // Only set the flag if the feature is enabled
-        if (this.showOnPRCreate) {
-          console.log('📝 Setting PR creation flag in storage');
-          chrome.storage.local.set({
-            prCreationTriggered: true,
-            prCreationTime: Date.now(),
-          });
-        } else {
-          console.log('🚫 PR creation banner disabled in settings');
-        }
-      });
-      createButton.setAttribute('data-elden-ring-listener', 'true');
-    }
-  }
-
-  private detectPRApprovalButtons(): void {
-    // Check if we're on a PR page (including files view)
-    const currentUrl = window.location.href;
-    const isPRPage = /\/pull\/\d+/.test(currentUrl);
-    if (!isPRPage) {
-      return;
-    }
-
-    // Look for "Submit review" buttons within dialog
-    const dialogElement = document.querySelector('div[role="dialog"]');
-    if (dialogElement) {
-      const buttons = Array.from(dialogElement.querySelectorAll('button'));
-      const submitButton = buttons.find((button) =>
-        button.textContent?.toLowerCase().includes('submit review'),
-      );
-
-      if (submitButton && !submitButton.hasAttribute('data-elden-ring-approval-listener')) {
-        submitButton.addEventListener('click', () => {
-          // Check if approve radio button is selected within the same dialog at click time
-          const approveRadio = dialogElement.querySelector(
-            'input[name="reviewEvent"][value="approve"]',
-          ) as HTMLInputElement;
-
-          if (approveRadio && approveRadio.checked) {
-            if (this.showOnPRApprove) {
-              console.log('🎯 Submit review with approval selected');
-              // Store approval flag for when we navigate back to PR page
-              chrome.storage.local.set({
-                prApprovalTriggered: true,
-                prApprovalTime: Date.now(),
-              });
-            } else {
-              console.log('🚫 PR approval banner disabled in settings');
-            }
-          }
-        });
-        submitButton.setAttribute('data-elden-ring-approval-listener', 'true');
-      }
-    }
-
-    // Also look for the approve radio button directly
-    const approveRadios = document.querySelectorAll('input[name="reviewEvent"][value="approve"]');
-    approveRadios.forEach((radio) => {
-      if (!radio.hasAttribute('data-elden-ring-approval-listener')) {
-        radio.addEventListener('change', () => {
-          if ((radio as HTMLInputElement).checked) {
-            console.log('🎯 Approve option selected');
-          }
-        });
-        radio.setAttribute('data-elden-ring-approval-listener', 'true');
-      }
-    });
-  }
-
-  private waitForMergeComplete(): void {
-    // Watch for the merged state to appear
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          if (node.nodeType === Node.ELEMENT_NODE) {
-            const element = node as Element;
-            // Check for merge success indicator
-            if (
-              element.querySelector('.State.State--merged') ||
-              element.matches('.State.State--merged')
-            ) {
-              console.log('✅ Merge completed successfully!');
-              if (this.showOnPRMerged) {
-                this.showEldenRingBanner();
-              } else {
-                console.log('🚫 PR merge banner disabled in settings');
-              }
-              observer.disconnect(); // Stop observing once we find the merged state
-            }
-          }
-        });
-      });
-    });
-
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-    });
-
-    // Also check if the merged state already exists (in case we missed it)
-    setTimeout(() => {
-      const mergedElement = document.querySelector('.State.State--merged');
-      if (mergedElement) {
-        console.log('✅ Merge state already present!');
-        if (this.showOnPRMerged) {
-          this.showEldenRingBanner();
-        } else {
-          console.log('🚫 PR merge banner disabled in settings');
-        }
-        observer.disconnect();
-      }
-    }, 100);
-
-    // Timeout after 10 seconds to avoid indefinite waiting
-    setTimeout(() => {
-      observer.disconnect();
-      console.log('⏰ Merge detection timeout');
-    }, 10000);
-  }
-
-  public showEldenRingBanner(type: BannerType = 'merged'): void {
+  public showEldenRingBanner(type: BannerType): void {
     if (this.bannerShown) return;
     this.bannerShown = true;
 
@@ -394,14 +91,27 @@ class EldenRingMerger {
     }
   }
 
-  private handleCloseCelebration(): void {
-    if (!this.showOnPRClose) {
-      console.log('🚫 PR close banner disabled in settings');
-      return;
-    }
-    this.showEldenRingBanner('closed');
+  private createFeatures(): GitHubFeature[] {
+    return [
+      new MergeFeature({
+        showSettings: this.showSettings,
+        onMerged: () => this.showEldenRingBanner('merged'),
+      }),
+      new CreationFeature({
+        showSettings: this.showSettings,
+        onCreated: () => this.showEldenRingBanner('created'),
+      }),
+      new ApprovalFeature({
+        showSettings: this.showSettings,
+        onApproved: () => this.showEldenRingBanner('approved'),
+      }),
+      new CloseFeature({
+        showSettings: this.showSettings,
+        onCloseCelebration: () => this.showEldenRingBanner('closed'),
+      }),
+    ];
   }
 }
 
 // Initialize the extension
-new EldenRingMerger();
+new EldenRingOrchestrator();

--- a/src/content/createHandler.ts
+++ b/src/content/createHandler.ts
@@ -1,0 +1,54 @@
+import { ShowSettings } from './showSettings';
+import { isPullRequestPage } from './pageUtils';
+
+export interface CreationSuccessOptions {
+  showSettings: ShowSettings;
+  onCreated: () => void;
+}
+
+export interface CreationButtonOptions {
+  showSettings: ShowSettings;
+}
+
+export const checkForPRCreationSuccess = (options: CreationSuccessOptions): void => {
+  if (!isPullRequestPage()) return;
+
+  chrome.storage.local.get(['prCreationTriggered', 'prCreationTime'], (result) => {
+    if (result.prCreationTriggered && result.prCreationTime) {
+      const timeDiff = Date.now() - result.prCreationTime;
+      if (timeDiff < 30000 && options.showSettings.isEnabled('created')) {
+        console.log('✅ PR creation detected via storage flag, showing banner');
+        options.onCreated();
+        chrome.storage.local.remove(['prCreationTriggered', 'prCreationTime']);
+      } else if (timeDiff < 30000 && !options.showSettings.isEnabled('created')) {
+        console.log('🚫 PR creation detected but disabled in settings');
+        chrome.storage.local.remove(['prCreationTriggered', 'prCreationTime']);
+      }
+    }
+  });
+};
+
+export const detectPRCreationButtons = (options: CreationButtonOptions): void => {
+  const currentUrl = window.location.href;
+  const isComparePage = /\/compare/.test(currentUrl);
+  if (!isComparePage) {
+    return;
+  }
+
+  const createButton = document.querySelector('.hx_create-pr-button');
+  if (createButton && !createButton.hasAttribute('data-elden-ring-listener')) {
+    createButton.addEventListener('click', () => {
+      console.log('🎯 Create pull request button clicked');
+      if (options.showSettings.isEnabled('created')) {
+        console.log('📝 Setting PR creation flag in storage');
+        chrome.storage.local.set({
+          prCreationTriggered: true,
+          prCreationTime: Date.now(),
+        });
+      } else {
+        console.log('🚫 PR creation banner disabled in settings');
+      }
+    });
+    createButton.setAttribute('data-elden-ring-listener', 'true');
+  }
+};

--- a/src/content/features.ts
+++ b/src/content/features.ts
@@ -1,0 +1,107 @@
+import { detectMergeButtons } from './mergeHandler';
+import { checkForPRCreationSuccess, detectPRCreationButtons } from './createHandler';
+import { checkForPRApprovalSuccess, detectPRApprovalButtons } from './approveHandler';
+import { detectCloseButtons } from './closeHandler';
+import { ShowSettings } from './showSettings';
+
+export interface GitHubFeature {
+  initialize(): void;
+  onDomChange(): void;
+}
+
+interface MergeFeatureOptions {
+  showSettings: ShowSettings;
+  onMerged: () => void;
+}
+
+export class MergeFeature implements GitHubFeature {
+  constructor(private options: MergeFeatureOptions) {}
+
+  private runDetection(): void {
+    detectMergeButtons({
+      showSettings: this.options.showSettings,
+      onMerged: this.options.onMerged,
+    });
+  }
+
+  initialize(): void {
+    this.runDetection();
+  }
+
+  onDomChange(): void {
+    this.runDetection();
+  }
+}
+
+interface CreationFeatureOptions {
+  showSettings: ShowSettings;
+  onCreated: () => void;
+}
+
+export class CreationFeature implements GitHubFeature {
+  constructor(private options: CreationFeatureOptions) {}
+
+  initialize(): void {
+    checkForPRCreationSuccess({
+      showSettings: this.options.showSettings,
+      onCreated: this.options.onCreated,
+    });
+    detectPRCreationButtons({
+      showSettings: this.options.showSettings,
+    });
+  }
+
+  onDomChange(): void {
+    detectPRCreationButtons({
+      showSettings: this.options.showSettings,
+    });
+  }
+}
+
+interface ApprovalFeatureOptions {
+  showSettings: ShowSettings;
+  onApproved: () => void;
+}
+
+export class ApprovalFeature implements GitHubFeature {
+  constructor(private options: ApprovalFeatureOptions) {}
+
+  initialize(): void {
+    checkForPRApprovalSuccess({
+      showSettings: this.options.showSettings,
+      onApproved: this.options.onApproved,
+    });
+    detectPRApprovalButtons({
+      showSettings: this.options.showSettings,
+    });
+  }
+
+  onDomChange(): void {
+    detectPRApprovalButtons({
+      showSettings: this.options.showSettings,
+    });
+  }
+}
+
+interface CloseFeatureOptions {
+  showSettings: ShowSettings;
+  onCloseCelebration: () => void;
+}
+
+export class CloseFeature implements GitHubFeature {
+  constructor(private options: CloseFeatureOptions) {}
+
+  initialize(): void {
+    detectCloseButtons({
+      showSettings: this.options.showSettings,
+      onClosed: this.options.onCloseCelebration,
+    });
+  }
+
+  onDomChange(): void {
+    detectCloseButtons({
+      showSettings: this.options.showSettings,
+      onClosed: this.options.onCloseCelebration,
+    });
+  }
+}

--- a/src/content/mergeHandler.test.ts
+++ b/src/content/mergeHandler.test.ts
@@ -15,9 +15,7 @@ describe('mergeHandler', () => {
     observerCallback = null;
 
     class MockMutationObserver {
-      private callback: (mutations: MutationRecord[]) => void;
       constructor(cb: (mutations: MutationRecord[]) => void) {
-        this.callback = cb;
         observerCallback = cb;
       }
       observe() {}
@@ -27,18 +25,21 @@ describe('mergeHandler', () => {
     (globalThis as any).MutationObserver = MockMutationObserver;
   });
 
+  const createShowSettings = (): ShowSettings =>
+    new ShowSettings(() => ({
+      showOnPRMerged: true,
+      showOnPRCreate: true,
+      showOnPRApprove: true,
+      showOnPRClose: true,
+    }));
+
   it('should trigger onMerged when merged state appears', () => {
     Object.defineProperty(window, 'location', {
       value: { href: 'https://github.com/user/repo/pull/1' },
       writable: true,
     });
     const onMerged = vi.fn();
-    const showSettings = new ShowSettings(() => ({
-      showOnPRMerged: true,
-      showOnPRCreate: true,
-      showOnPRApprove: true,
-      showOnPRClose: true,
-    }));
+    const showSettings = createShowSettings();
     detectMergeButtons({
       showSettings,
       onMerged,
@@ -65,12 +66,7 @@ describe('mergeHandler', () => {
       writable: true,
     });
     const onMerged = vi.fn();
-    const showSettings = new ShowSettings(() => ({
-      showOnPRMerged: true,
-      showOnPRCreate: true,
-      showOnPRApprove: true,
-      showOnPRClose: true,
-    }));
+    const showSettings = createShowSettings();
     detectMergeButtons({
       showSettings,
       onMerged,

--- a/src/content/mergeHandler.test.ts
+++ b/src/content/mergeHandler.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { detectMergeButtons } from './mergeHandler';
+import { ShowSettings } from './showSettings';
+
+describe('mergeHandler', () => {
+  let observerCallback: ((mutations: MutationRecord[]) => void) | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="merge-pr">
+        <button>Confirm merge</button>
+      </div>
+    `;
+
+    observerCallback = null;
+
+    class MockMutationObserver {
+      private callback: (mutations: MutationRecord[]) => void;
+      constructor(cb: (mutations: MutationRecord[]) => void) {
+        this.callback = cb;
+        observerCallback = cb;
+      }
+      observe() {}
+      disconnect() {}
+    }
+
+    (globalThis as any).MutationObserver = MockMutationObserver;
+  });
+
+  it('should trigger onMerged when merged state appears', () => {
+    Object.defineProperty(window, 'location', {
+      value: { href: 'https://github.com/user/repo/pull/1' },
+      writable: true,
+    });
+    const onMerged = vi.fn();
+    const showSettings = new ShowSettings(() => ({
+      showOnPRMerged: true,
+      showOnPRCreate: true,
+      showOnPRApprove: true,
+      showOnPRClose: true,
+    }));
+    detectMergeButtons({
+      showSettings,
+      onMerged,
+    });
+
+    const button = document.querySelector('button');
+    button?.dispatchEvent(new Event('click'));
+
+    const mergedElement = document.createElement('div');
+    mergedElement.className = 'State State--merged';
+
+    observerCallback?.([
+      {
+        addedNodes: [mergedElement],
+      } as unknown as MutationRecord,
+    ]);
+
+    expect(onMerged).toHaveBeenCalled();
+  });
+
+  it('should not attach listeners if not on PR page', () => {
+    Object.defineProperty(window, 'location', {
+      value: { href: 'https://github.com/user/repo' },
+      writable: true,
+    });
+    const onMerged = vi.fn();
+    const showSettings = new ShowSettings(() => ({
+      showOnPRMerged: true,
+      showOnPRCreate: true,
+      showOnPRApprove: true,
+      showOnPRClose: true,
+    }));
+    detectMergeButtons({
+      showSettings,
+      onMerged,
+    });
+
+    const button = document.querySelector('button');
+    button?.dispatchEvent(new Event('click'));
+
+    expect(onMerged).not.toHaveBeenCalled();
+  });
+});

--- a/src/content/mergeHandler.ts
+++ b/src/content/mergeHandler.ts
@@ -1,0 +1,88 @@
+import { ShowSettings } from './showSettings';
+import { isPullRequestPage } from './pageUtils';
+
+export interface MergeHandlerOptions {
+  showSettings: ShowSettings;
+  onMerged: () => void;
+}
+
+export const detectMergeButtons = (options: MergeHandlerOptions): void => {
+  if (!isPullRequestPage()) {
+    return;
+  }
+
+  const mergePrContainer = document.querySelector('.merge-pr');
+  if (!mergePrContainer) {
+    return;
+  }
+
+  const buttons = mergePrContainer.querySelectorAll('button');
+  buttons.forEach((button) => {
+    const buttonText = button.textContent?.toLowerCase().trim() || '';
+    const specificMergeTexts = [
+      'confirm merge',
+      'confirm squash and merge',
+      'confirm rebase and merge',
+    ];
+
+    if (
+      specificMergeTexts.some((text) => buttonText.includes(text)) &&
+      !button.hasAttribute('data-elden-ring-listener')
+    ) {
+      button.addEventListener('click', () => {
+        console.log('🎯 Merge button clicked:', buttonText);
+        waitForMergeComplete(options);
+      });
+      button.setAttribute('data-elden-ring-listener', 'true');
+    }
+  });
+};
+
+const waitForMergeComplete = (options: MergeHandlerOptions): void => {
+  const { showSettings, onMerged } = options;
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as Element;
+          if (
+            element.querySelector('.State.State--merged') ||
+            element.matches('.State.State--merged')
+          ) {
+            console.log('✅ Merge completed successfully!');
+            if (showSettings.isEnabled('merged')) {
+              onMerged();
+            } else {
+              console.log('🚫 PR merge banner disabled in settings');
+            }
+            observer.disconnect();
+          }
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  setTimeout(() => {
+    const mergedElement = document.querySelector('.State.State--merged');
+    if (mergedElement) {
+      console.log('✅ Merge state already present!');
+      if (showSettings.isEnabled('merged')) {
+        onMerged();
+      } else {
+        console.log('🚫 PR merge banner disabled in settings');
+      }
+      observer.disconnect();
+    }
+  }, 100);
+
+  setTimeout(() => {
+    observer.disconnect();
+    console.log('⏰ Merge detection timeout');
+  }, 10000);
+};

--- a/src/content/pageUtils.ts
+++ b/src/content/pageUtils.ts
@@ -1,0 +1,1 @@
+export const isPullRequestPage = (): boolean => /\/pull\/\d+/.test(window.location.href);

--- a/src/content/settingsStore.ts
+++ b/src/content/settingsStore.ts
@@ -1,0 +1,96 @@
+export interface SettingsState {
+  soundEnabled: boolean;
+  soundType: 'you-die-sound' | 'lost-grace-discovered';
+  showOnPRMerged: boolean;
+  showOnPRCreate: boolean;
+  showOnPRApprove: boolean;
+  showOnPRClose: boolean;
+}
+
+const defaultState: SettingsState = {
+  soundEnabled: true,
+  soundType: 'you-die-sound',
+  showOnPRMerged: true,
+  showOnPRCreate: true,
+  showOnPRApprove: true,
+  showOnPRClose: true,
+};
+
+export class SettingsStore {
+  private state: SettingsState = defaultState;
+  private subscribers: Array<(state: SettingsState) => void> = [];
+
+  init(): void {
+    chrome.storage.sync.get(
+      [
+        'soundEnabled',
+        'soundType',
+        'showOnPRMerged',
+        'showOnPRCreate',
+        'showOnPRApprove',
+        'showOnPRClose',
+      ],
+      (result) => {
+        this.state = {
+          soundEnabled: result.soundEnabled !== false,
+          soundType: result.soundType || 'you-die-sound',
+          showOnPRMerged: result.showOnPRMerged !== false,
+          showOnPRCreate: result.showOnPRCreate !== false,
+          showOnPRApprove: result.showOnPRApprove !== false,
+          showOnPRClose: result.showOnPRClose !== false,
+        };
+        this.notify();
+      },
+    );
+
+    chrome.storage.onChanged.addListener((changes) => {
+      let updated = false;
+      const nextState = { ...this.state };
+
+      if (changes.soundEnabled) {
+        nextState.soundEnabled = changes.soundEnabled.newValue;
+        updated = true;
+      }
+      if (changes.soundType) {
+        nextState.soundType = changes.soundType.newValue;
+        updated = true;
+      }
+      if (changes.showOnPRMerged) {
+        nextState.showOnPRMerged = changes.showOnPRMerged.newValue;
+        updated = true;
+      }
+      if (changes.showOnPRCreate) {
+        nextState.showOnPRCreate = changes.showOnPRCreate.newValue;
+        updated = true;
+      }
+      if (changes.showOnPRApprove) {
+        nextState.showOnPRApprove = changes.showOnPRApprove.newValue;
+        updated = true;
+      }
+      if (changes.showOnPRClose) {
+        nextState.showOnPRClose = changes.showOnPRClose.newValue;
+        updated = true;
+      }
+
+      if (updated) {
+        this.state = nextState;
+        this.notify();
+      }
+    });
+  }
+
+  getState(): SettingsState {
+    return this.state;
+  }
+
+  subscribe(listener: (state: SettingsState) => void): () => void {
+    this.subscribers.push(listener);
+    return () => {
+      this.subscribers = this.subscribers.filter((cb) => cb !== listener);
+    };
+  }
+
+  private notify(): void {
+    this.subscribers.forEach((listener) => listener(this.state));
+  }
+}

--- a/src/content/showSettings.ts
+++ b/src/content/showSettings.ts
@@ -1,0 +1,19 @@
+import type { SettingsState } from './settingsStore';
+
+export type ShowSettingKey = 'merged' | 'created' | 'approved' | 'closed';
+
+const STATE_KEY_MAP: Record<ShowSettingKey, keyof SettingsState> = {
+  merged: 'showOnPRMerged',
+  created: 'showOnPRCreate',
+  approved: 'showOnPRApprove',
+  closed: 'showOnPRClose',
+};
+
+export class ShowSettings {
+  constructor(private stateProvider: () => SettingsState) {}
+
+  isEnabled(setting: ShowSettingKey): boolean {
+    const key = STATE_KEY_MAP[setting];
+    return this.stateProvider()[key];
+  }
+}

--- a/src/content/showSettings.ts
+++ b/src/content/showSettings.ts
@@ -2,7 +2,12 @@ import type { SettingsState } from './settingsStore';
 
 export type ShowSettingKey = 'merged' | 'created' | 'approved' | 'closed';
 
-const STATE_KEY_MAP: Record<ShowSettingKey, keyof SettingsState> = {
+type ShowSettingsFlags = Pick<
+  SettingsState,
+  'showOnPRMerged' | 'showOnPRCreate' | 'showOnPRApprove' | 'showOnPRClose'
+>;
+
+const STATE_KEY_MAP: Record<ShowSettingKey, keyof ShowSettingsFlags> = {
   merged: 'showOnPRMerged',
   created: 'showOnPRCreate',
   approved: 'showOnPRApprove',
@@ -10,7 +15,7 @@ const STATE_KEY_MAP: Record<ShowSettingKey, keyof SettingsState> = {
 };
 
 export class ShowSettings {
-  constructor(private stateProvider: () => SettingsState) {}
+  constructor(private stateProvider: () => ShowSettingsFlags) {}
 
   isEnabled(setting: ShowSettingKey): boolean {
     const key = STATE_KEY_MAP[setting];


### PR DESCRIPTION
## Summary

This PR refactors the content script architecture by extracting feature-specific handlers into separate modules, improving code organization, maintainability, and testability. The monolithic `EldenRingMerger` class has been replaced with a feature-based architecture using dedicated handler modules and a centralized settings management system.

### Key Changes

- **Extracted feature handlers**: Split PR merge, creation, approval, and close detection into separate handler modules (`mergeHandler.ts`, `createHandler.ts`, `approveHandler.ts`, `closeHandler.ts`)
- **Introduced feature pattern**: Created `features.ts` with a `GitHubFeature` interface and feature classes (`MergeFeature`, `CreationFeature`, `ApprovalFeature`, `CloseFeature`) for consistent lifecycle management
- **Centralized settings management**: Implemented `SettingsStore` for state management and `ShowSettings` for feature-specific settings queries
- **Renamed main orchestrator**: Changed `EldenRingMerger` to `EldenRingOrchestrator` to better reflect its coordinating role
- **Improved type safety**: Enhanced `ShowSettings` with proper TypeScript typing and removed implicit any types
- **Added comprehensive tests**: Created `mergeHandler.test.ts` with test coverage for merge detection logic

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/formatting changes
- [x] 🧪 Test improvements
- [ ] 🔧 Configuration changes

## Test Plan

### Manual Testing

- Verify PR merge detection still works by merging a test PR (banner should appear)
- Verify PR creation detection by creating a new PR from compare page
- Verify PR approval detection by approving a PR in the Files view
- Verify PR close detection by closing an open PR
- Confirm all banner types (merged, created, approved, closed) render correctly
- Test that settings toggles (showOnPRMerged, showOnPRCreate, etc.) still control feature behavior

### Automated Testing

- Run `npm test` to verify `mergeHandler.test.ts` passes
- Verify test coverage for merge button detection and observer pattern

## Breaking Changes

None

## Checklist

- [x] 📝 Code follows the style guidelines
- [x] 👀 Self-review has been performed
- [x] 🧪 Tests have been added/updated
- [x] 📖 Documentation has been updated
