### PR TITLE
feat: animate merge banner and add custom text / volume controls

### DIFF
--- a/src/content/banner.test.ts
+++ b/src/content/banner.test.ts
@@ -3,6 +3,37 @@ import { renderBanner, type BannerType } from './banner';
 
 describe('renderBanner', () => {
   const soundUrl = 'chrome-extension://mock/sound.mp3';
+  let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+  let audioInstances: HTMLAudioElement[];
+
+  const createMockGradient = () => ({
+    addColorStop: vi.fn(),
+  });
+
+  const createMockContext = () =>
+    ({
+      setTransform: vi.fn(),
+      clearRect: vi.fn(),
+      createRadialGradient: vi.fn().mockImplementation(createMockGradient),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      stroke: vi.fn(),
+      strokeText: vi.fn(),
+      fillText: vi.fn(),
+      textAlign: 'center',
+      textBaseline: 'middle',
+      lineWidth: 0,
+      fillStyle: '',
+      strokeStyle: '',
+      font: '',
+      shadowBlur: 0,
+      shadowColor: '',
+    }) as unknown as CanvasRenderingContext2D;
 
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -15,16 +46,23 @@ describe('renderBanner', () => {
     chromeGlobal.chrome.runtime = chromeGlobal.chrome.runtime || {};
     chromeGlobal.chrome.runtime.getURL = vi.fn((path: string) => `chrome-extension://mock/${path}`);
 
+    audioInstances = [];
     global.Audio = vi.fn().mockImplementation(() => {
-      return {
+      const instance = {
         play: vi.fn().mockResolvedValue(undefined),
         volume: 0,
       } as unknown as HTMLAudioElement;
+      audioInstances.push(instance);
+      return instance;
     });
+
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockImplementation(() => createMockContext());
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
   });
 
   it('should render banners for each type', () => {
@@ -41,9 +79,7 @@ describe('renderBanner', () => {
 
       const banner = document.getElementById('elden-ring-banner');
       expect(banner).toBeTruthy();
-      expect(banner?.innerHTML).toContain('.png');
-      const chromeRuntime = (globalThis as any).chrome.runtime;
-      expect(chromeRuntime.getURL).toHaveBeenCalled();
+      expect(banner?.querySelector('canvas')).toBeTruthy();
 
       vi.runAllTimers();
       expect(onHide).toHaveBeenCalled();
@@ -64,5 +100,77 @@ describe('renderBanner', () => {
     expect(global.Audio).not.toHaveBeenCalled();
     vi.runAllTimers();
     expect(onHide).toHaveBeenCalled();
+  });
+
+  it('should use custom text when provided', () => {
+    const onHide = vi.fn();
+    renderBanner({
+      type: 'merged',
+      soundUrl,
+      soundEnabled: false,
+      customText: 'LEGENDARY DEPLOY',
+      onHide,
+    });
+
+    const canvas = document.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+    vi.runOnlyPendingTimers();
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to default text when customText is blank', () => {
+    renderBanner({
+      type: 'merged',
+      soundUrl,
+      soundEnabled: false,
+      customText: '   ',
+      onHide: vi.fn(),
+    });
+
+    expect(document.getElementById('elden-ring-banner')).toBeTruthy();
+  });
+
+  it('should truncate customText beyond 48 characters', () => {
+    const longText = 'A'.repeat(60);
+    renderBanner({
+      type: 'merged',
+      soundUrl,
+      soundEnabled: false,
+      customText: longText,
+      onHide: vi.fn(),
+    });
+
+    expect(document.getElementById('elden-ring-banner')).toBeTruthy();
+  });
+
+  it('defaults audio volume to 1 when soundVolume is not provided', () => {
+    renderBanner({
+      type: 'merged',
+      soundUrl,
+      soundEnabled: true,
+      onHide: vi.fn(),
+    });
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0]!.volume).toBe(1);
+  });
+
+  it.each([
+    [0, 0],
+    [0.5, 0.5],
+    [1, 1],
+    [1.5, 1],
+    [-0.2, 0],
+  ])('clamps soundVolume %s to %s', (input, expected) => {
+    renderBanner({
+      type: 'merged',
+      soundUrl,
+      soundEnabled: true,
+      soundVolume: input,
+      onHide: vi.fn(),
+    });
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0]!.volume).toBe(expected);
   });
 });

--- a/src/content/banner.ts
+++ b/src/content/banner.ts
@@ -4,66 +4,178 @@ interface RenderBannerOptions {
   type: BannerType;
   soundUrl: string;
   soundEnabled: boolean;
+  soundVolume?: number;
+  customText?: string;
   onHide: () => void;
 }
 
-const bannerAssetMap: Record<BannerType, { image: string; alt: string }> = {
-  merged: {
-    image: 'pull-request-merged.png',
-    alt: 'Pull Request Merged',
-  },
-  created: {
-    image: 'pull-request-created.png',
-    alt: 'Pull Request Created',
-  },
-  approved: {
-    image: 'approve-pull-request.png',
-    alt: 'Pull Request Approved',
-  },
-  closed: {
-    image: 'close-pull-request.png',
-    alt: 'Pull Request Closed',
-  },
+const DEFAULT_BANNER_TEXT: Record<BannerType, string> = {
+  merged: 'MERGE ACCOMPLISHED',
+  created: 'PR FORGED',
+  approved: 'REVIEW APPROVED',
+  closed: 'YOU DIED',
 };
 
-/**
- * Renders the Elden Ring banner with correct imagery and optional audio with safe cleanup.
- */
+const DEFAULT_SUBTITLE: Record<BannerType, string> = {
+  merged: 'The pull request has been merged',
+  created: 'A new pull request has been created',
+  approved: 'A pull request review was approved',
+  closed: 'A pull request has been closed',
+};
+
+const SHOW_CLASS_DELAY_MS = 50;
+const DISPLAY_DURATION_MS = 3000;
+const HIDE_ANIMATION_MS = 500;
+const FRAME_DURATION_MS = 16;
+const MAX_CUSTOM_TEXT_LENGTH = 48;
+
+const sanitizeBannerText = (text?: string): string | undefined => {
+  if (!text) return undefined;
+  const trimmed = text.trim();
+  return trimmed ? trimmed.slice(0, MAX_CUSTOM_TEXT_LENGTH) : undefined;
+};
+
+const getNow = (): number =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const requestFrame = (callback: (time: number) => void): number => {
+  if (typeof window.requestAnimationFrame === 'function') {
+    return window.requestAnimationFrame(callback);
+  }
+  return window.setTimeout(() => callback(getNow()), FRAME_DURATION_MS);
+};
+
+const cancelFrame = (frameId: number): void => {
+  if (typeof window.cancelAnimationFrame === 'function') {
+    window.cancelAnimationFrame(frameId);
+    return;
+  }
+  clearTimeout(frameId);
+};
+
 export const renderBanner = ({
   type,
   soundUrl,
   soundEnabled,
+  soundVolume,
+  customText,
   onHide,
 }: RenderBannerOptions): boolean => {
   try {
+    const text = sanitizeBannerText(customText) ?? DEFAULT_BANNER_TEXT[type];
+    const subtitle = DEFAULT_SUBTITLE[type];
     const banner = document.createElement('div');
     banner.id = 'elden-ring-banner';
-
-    const asset = bannerAssetMap[type];
-    const imgPath = chrome.runtime.getURL(`assets/${asset.image}`);
-
-    const img = document.createElement('img');
-    img.src = imgPath;
-    img.alt = asset.alt;
-    banner.appendChild(img);
+    const canvas = document.createElement('canvas');
+    canvas.className = 'elden-ring-banner-canvas';
+    banner.appendChild(canvas);
     document.body.appendChild(banner);
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      banner.remove();
+      throw new Error('Canvas 2D context is unavailable');
+    }
+
+    let frameId = 0;
+    let isRemoved = false;
+
+    const renderFrame = (timestamp: number): void => {
+      if (isRemoved) {
+        return;
+      }
+
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const dpr = window.devicePixelRatio || 1;
+
+      if (canvas.width !== Math.floor(width * dpr) || canvas.height !== Math.floor(height * dpr)) {
+        canvas.width = Math.floor(width * dpr);
+        canvas.height = Math.floor(height * dpr);
+      }
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      context.clearRect(0, 0, width, height);
+
+      const progress = (timestamp % 2000) / 2000;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const glowSize = Math.min(width, height) * 0.22;
+
+      const background = context.createRadialGradient(
+        centerX,
+        centerY,
+        0,
+        centerX,
+        centerY,
+        glowSize,
+      );
+      background.addColorStop(0, 'rgba(212, 175, 55, 0.20)');
+      background.addColorStop(0.6, 'rgba(35, 28, 16, 0.55)');
+      background.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      context.fillStyle = background;
+      context.fillRect(0, 0, width, height);
+
+      context.save();
+      context.translate(centerX, centerY);
+      context.rotate(progress * Math.PI * 2);
+      context.lineWidth = 2;
+      context.strokeStyle = 'rgba(212, 175, 55, 0.55)';
+      context.beginPath();
+      context.arc(0, 0, glowSize * 0.75, 0, Math.PI * 1.5);
+      context.stroke();
+      context.rotate(-progress * Math.PI * 3.4);
+      context.strokeStyle = 'rgba(255, 240, 180, 0.35)';
+      context.beginPath();
+      context.arc(0, 0, glowSize * 0.58, 0, Math.PI * 1.3);
+      context.stroke();
+      context.restore();
+
+      const titleFontSize = Math.max(42, Math.min(width * 0.085, 110));
+      const subtitleFontSize = Math.max(16, Math.min(width * 0.024, 28));
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+
+      context.font = `700 ${titleFontSize}px "Cinzel", "Times New Roman", serif`;
+      context.strokeStyle = 'rgba(20, 12, 2, 0.95)';
+      context.lineWidth = 8;
+      context.strokeText(text, centerX, centerY - subtitleFontSize);
+      context.fillStyle = '#f2d87f';
+      context.shadowColor = 'rgba(243, 206, 84, 0.85)';
+      context.shadowBlur = 24 + Math.sin(progress * Math.PI * 2) * 7;
+      context.fillText(text, centerX, centerY - subtitleFontSize);
+
+      context.shadowBlur = 0;
+      context.font = `500 ${subtitleFontSize}px "Times New Roman", serif`;
+      context.fillStyle = 'rgba(232, 215, 160, 0.95)';
+      context.fillText(subtitle, centerX, centerY + titleFontSize * 0.5);
+
+      frameId = requestFrame(renderFrame);
+    };
 
     if (soundEnabled) {
       const audio = new Audio(soundUrl);
-      audio.volume = 1.0;
+      audio.volume = Math.min(1, Math.max(0, soundVolume ?? 1));
       audio.play().catch((err) => console.log('Sound playback failed:', err));
     }
 
-    setTimeout(() => banner.classList.add('show'), 50);
+    frameId = requestFrame(renderFrame);
+    setTimeout(() => banner.classList.add('show'), SHOW_CLASS_DELAY_MS);
     setTimeout(() => {
       banner.classList.remove('show');
       setTimeout(() => {
+        isRemoved = true;
+        cancelFrame(frameId);
         if (banner.parentNode) {
           banner.remove();
         }
         onHide();
-      }, 500);
-    }, 3000);
+      }, HIDE_ANIMATION_MS);
+    }, DISPLAY_DURATION_MS);
 
     return true;
   } catch (error) {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -13,6 +13,8 @@ class EldenRingOrchestrator {
   private bannerShown: boolean = false;
   private soundEnabled: boolean = true;
   private soundType: SoundType = 'you-die-sound';
+  private soundVolume: number = 1;
+  private customBannerText: string = '';
   private soundUrl: string;
   private features: GitHubFeature[] = [];
   private showSettings = new ShowSettings();
@@ -35,6 +37,8 @@ class EldenRingOrchestrator {
   private applySettings(state: SettingsState): void {
     this.soundEnabled = state.soundEnabled;
     this.soundType = state.soundType;
+    this.soundVolume = state.soundVolume;
+    this.customBannerText = state.customBannerText;
     this.updateSoundUrl();
   }
 
@@ -75,6 +79,8 @@ class EldenRingOrchestrator {
       type,
       soundUrl: defaultSoundUrl,
       soundEnabled: this.soundEnabled,
+      soundVolume: this.soundVolume,
+      customText: this.customBannerText,
       onHide: () => {
         this.bannerShown = false;
       },

--- a/src/content/showSettings.ts
+++ b/src/content/showSettings.ts
@@ -3,6 +3,8 @@ import type { SoundType } from '../types/sounds';
 export interface SettingsState {
   soundEnabled: boolean;
   soundType: SoundType;
+  soundVolume: number;
+  customBannerText: string;
   showOnPRMerged: boolean;
   showOnPRCreate: boolean;
   showOnPRApprove: boolean;
@@ -26,6 +28,8 @@ const STATE_KEY_MAP: Record<ShowSettingKey, keyof ShowSettingsFlags> = {
 const defaultState: SettingsState = {
   soundEnabled: true,
   soundType: 'you-die-sound',
+  soundVolume: 1,
+  customBannerText: '',
   showOnPRMerged: true,
   showOnPRCreate: true,
   showOnPRApprove: true,
@@ -51,6 +55,8 @@ export class ShowSettings {
       [
         'soundEnabled',
         'soundType',
+        'soundVolume',
+        'customBannerText',
         'showOnPRMerged',
         'showOnPRCreate',
         'showOnPRApprove',
@@ -60,6 +66,9 @@ export class ShowSettings {
         this.state = {
           soundEnabled: result.soundEnabled !== false,
           soundType: result.soundType || 'you-die-sound',
+          soundVolume: typeof result.soundVolume === 'number' ? result.soundVolume : 1,
+          customBannerText:
+            typeof result.customBannerText === 'string' ? result.customBannerText : '',
           showOnPRMerged: result.showOnPRMerged !== false,
           showOnPRCreate: result.showOnPRCreate !== false,
           showOnPRApprove: result.showOnPRApprove !== false,
@@ -79,6 +88,18 @@ export class ShowSettings {
       }
       if (changes.soundType) {
         nextState.soundType = changes.soundType.newValue;
+        updated = true;
+      }
+      if (changes.soundVolume) {
+        nextState.soundVolume =
+          typeof changes.soundVolume.newValue === 'number' ? changes.soundVolume.newValue : 1;
+        updated = true;
+      }
+      if (changes.customBannerText) {
+        nextState.customBannerText =
+          typeof changes.customBannerText.newValue === 'string'
+            ? changes.customBannerText.newValue
+            : '';
         updated = true;
       }
       if (changes.showOnPRMerged) {

--- a/src/content/styles.css
+++ b/src/content/styles.css
@@ -19,11 +19,9 @@
   transform: translate(-50%, -50%) scale(1);
 }
 
-#elden-ring-banner img {
+.elden-ring-banner-canvas {
   width: 100vw;
-  max-width: 100vw;
-  height: auto;
-  filter: drop-shadow(0 0 10px black);
+  height: 100vh;
   display: block;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -215,6 +215,32 @@ body {
   margin-left: 8px;
 }
 
+.setting-label-column {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.setting-label input[type='text'] {
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid #d4af37;
+  color: #d4af37;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+}
+
+.setting-label input[type='text']::placeholder {
+  color: rgba(212, 175, 55, 0.5);
+}
+
+.setting-label input[type='range'] {
+  width: 100%;
+  accent-color: #d4af37;
+  cursor: pointer;
+}
+
 .info-section {
   margin-bottom: 20px;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -64,6 +64,12 @@
           </label>
         </div>
         <div class="setting-item">
+          <label class="setting-label setting-label-column" for="soundVolume">
+            Sound Volume:
+            <input id="soundVolume" type="range" min="0" max="100" step="5" value="100" />
+          </label>
+        </div>
+        <div class="setting-item">
           <label class="setting-label">
             Sound Type:
             <select id="soundType">
@@ -83,6 +89,17 @@
               <option value="7000">7 seconds</option>
               <option value="10000">10 seconds</option>
             </select>
+          </label>
+        </div>
+        <div class="setting-item">
+          <label class="setting-label setting-label-column" for="customBannerText">
+            Custom Banner Text:
+            <input
+              id="customBannerText"
+              type="text"
+              maxlength="48"
+              placeholder="e.g. MERGE ACCOMPLISHED"
+            />
           </label>
         </div>
       </div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -7,8 +7,10 @@ document.addEventListener('DOMContentLoaded', (): void => {
   const showOnPRCreateCheckbox = document.getElementById('showOnPRCreate') as HTMLInputElement;
   const showOnPRApproveCheckbox = document.getElementById('showOnPRApprove') as HTMLInputElement;
   const showOnPRCloseCheckbox = document.getElementById('showOnPRClose') as HTMLInputElement;
+  const soundVolumeInput = document.getElementById('soundVolume') as HTMLInputElement;
   const soundTypeSelect = document.getElementById('soundType') as HTMLSelectElement;
   const durationSelect = document.getElementById('duration') as HTMLSelectElement;
+  const customBannerTextInput = document.getElementById('customBannerText') as HTMLInputElement;
   const pageStatusElement = document.getElementById('pageStatus') as HTMLSpanElement;
 
   // Check current page
@@ -24,8 +26,10 @@ document.addEventListener('DOMContentLoaded', (): void => {
   showOnPRCreateCheckbox?.addEventListener('change', saveSettings);
   showOnPRApproveCheckbox?.addEventListener('change', saveSettings);
   showOnPRCloseCheckbox?.addEventListener('change', saveSettings);
+  soundVolumeInput?.addEventListener('change', saveSettings);
   soundTypeSelect?.addEventListener('change', saveSettings);
   durationSelect?.addEventListener('change', saveSettings);
+  customBannerTextInput?.addEventListener('change', saveSettings);
 
   function checkCurrentPage(): void {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs: chrome.tabs.Tab[]) => {
@@ -44,6 +48,8 @@ document.addEventListener('DOMContentLoaded', (): void => {
   }
 
   function showTestBanner() {
+    const customBannerText = customBannerTextInput?.value?.trim() || '';
+    const soundVolume = soundVolumeInput ? parseInt(soundVolumeInput.value, 10) / 100 : 1;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       const currentTab = tabs[0];
       if (currentTab) {
@@ -51,6 +57,7 @@ document.addEventListener('DOMContentLoaded', (): void => {
         chrome.scripting.executeScript({
           target: { tabId: currentTab.id! },
           func: createAndShowBanner,
+          args: [customBannerText, soundVolume],
         });
       }
     });
@@ -64,8 +71,10 @@ document.addEventListener('DOMContentLoaded', (): void => {
         'showOnPRCreate',
         'showOnPRApprove',
         'soundType',
+        'soundVolume',
         'duration',
         'showOnPRClose',
+        'customBannerText',
       ],
       function (result) {
         showOnPRMergedCheckbox.checked = result.showOnPRMerged !== false; // default true
@@ -74,7 +83,12 @@ document.addEventListener('DOMContentLoaded', (): void => {
         showOnPRApproveCheckbox.checked = result.showOnPRApprove !== false; // default true
         showOnPRCloseCheckbox.checked = result.showOnPRClose !== false; // default true
         soundTypeSelect.value = result.soundType || 'you-die-sound'; // default you-die-sound
+        soundVolumeInput.value = String(
+          typeof result.soundVolume === 'number' ? Math.round(result.soundVolume * 100) : 100,
+        ); // default 100%
         durationSelect.value = result.duration || '5000'; // default 5 seconds
+        customBannerTextInput.value =
+          typeof result.customBannerText === 'string' ? result.customBannerText : '';
       },
     );
   }
@@ -87,7 +101,9 @@ document.addEventListener('DOMContentLoaded', (): void => {
       showOnPRApprove: showOnPRApproveCheckbox.checked,
       showOnPRClose: showOnPRCloseCheckbox.checked,
       soundType: soundTypeSelect.value,
+      soundVolume: parseInt(soundVolumeInput.value, 10) / 100,
       duration: parseInt(durationSelect.value),
+      customBannerText: customBannerTextInput.value.trim(),
     };
 
     chrome.storage.sync.set(settings, function () {
@@ -109,40 +125,155 @@ document.addEventListener('DOMContentLoaded', (): void => {
 });
 
 // Functions to be injected into the content script
-function createAndShowBanner(): boolean {
+function createAndShowBanner(
+  initialCustomText: string = '',
+  initialSoundVolume: number = 1,
+): boolean {
   // Remove existing banner if any
-  const existingBanner = document.querySelector('#elden-ring-banner, .elden-ring-merge-banner');
+  const existingBanner = document.querySelector('#elden-ring-banner');
   if (existingBanner) {
     existingBanner.remove();
   }
 
-  // Try to create image banner first
   try {
     const banner = document.createElement('div');
     banner.id = 'elden-ring-banner';
-    const imgPath = chrome.runtime.getURL('assets/approve-pull-request.png');
-    banner.innerHTML = `<img src="${imgPath}" alt="Pull Request Approved">`;
+    Object.assign(banner.style, {
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%) scale(0.85)',
+      opacity: '0',
+      zIndex: '999999',
+      transition: 'all 0.5s ease-out',
+      pointerEvents: 'none',
+      width: '100vw',
+      height: '100vh',
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    banner.appendChild(canvas);
     document.body.appendChild(banner);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas 2D context unavailable');
+    }
+
+    const requestFrame = (callback: (time: number) => void): number => {
+      if (typeof window.requestAnimationFrame === 'function') {
+        return window.requestAnimationFrame(callback);
+      }
+      return window.setTimeout(() => callback(Date.now()), 16);
+    };
+
+    const cancelFrame = (frameId: number): void => {
+      if (typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(frameId);
+        return;
+      }
+      clearTimeout(frameId);
+    };
+
+    let frameId = 0;
+    let isRemoved = false;
+    const safeText = (initialCustomText || '').trim().slice(0, 48) || 'MERGE ACCOMPLISHED';
+
+    const drawFrame = (timestamp: number): void => {
+      if (isRemoved) {
+        return;
+      }
+
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      context.clearRect(0, 0, width, height);
+
+      const progress = (timestamp % 2000) / 2000;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const glowSize = Math.min(width, height) * 0.22;
+
+      const gradient = context.createRadialGradient(
+        centerX,
+        centerY,
+        0,
+        centerX,
+        centerY,
+        glowSize,
+      );
+      gradient.addColorStop(0, 'rgba(212, 175, 55, 0.20)');
+      gradient.addColorStop(0.6, 'rgba(35, 28, 16, 0.55)');
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      context.fillStyle = gradient;
+      context.fillRect(0, 0, width, height);
+
+      context.save();
+      context.translate(centerX, centerY);
+      context.rotate(progress * Math.PI * 2);
+      context.lineWidth = 2;
+      context.strokeStyle = 'rgba(212, 175, 55, 0.55)';
+      context.beginPath();
+      context.arc(0, 0, glowSize * 0.75, 0, Math.PI * 1.5);
+      context.stroke();
+      context.restore();
+
+      const titleFontSize = Math.max(42, Math.min(width * 0.085, 110));
+      const subtitleFontSize = Math.max(16, Math.min(width * 0.024, 28));
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+
+      context.font = `700 ${titleFontSize}px "Cinzel", "Times New Roman", serif`;
+      context.strokeStyle = 'rgba(20, 12, 2, 0.95)';
+      context.lineWidth = 8;
+      context.strokeText(safeText, centerX, centerY - subtitleFontSize);
+      context.fillStyle = '#f2d87f';
+      context.shadowColor = 'rgba(243, 206, 84, 0.85)';
+      context.shadowBlur = 24 + Math.sin(progress * Math.PI * 2) * 7;
+      context.fillText(safeText, centerX, centerY - subtitleFontSize);
+
+      context.shadowBlur = 0;
+      context.font = `500 ${subtitleFontSize}px "Times New Roman", serif`;
+      context.fillStyle = 'rgba(232, 215, 160, 0.95)';
+      context.fillText(
+        'Test banner activated from extension popup',
+        centerX,
+        centerY + titleFontSize * 0.5,
+      );
+
+      frameId = requestFrame(drawFrame);
+    };
 
     // Play sound effect if enabled
     chrome.storage.sync.get(['soundEnabled', 'soundType'], function (soundResult) {
       if (soundResult.soundEnabled !== false) {
         const soundType = soundResult.soundType || 'you-die-sound';
         const audio = new Audio(chrome.runtime.getURL(`assets/${soundType}.mp3`));
-        audio.volume = 1.0;
+        audio.volume = Math.min(1, Math.max(0, initialSoundVolume));
         audio.play().catch((err) => console.log('Sound playback failed:', err));
       }
     });
 
-    setTimeout(() => banner.classList.add('show'), 50);
+    frameId = requestFrame(drawFrame);
+    setTimeout(() => {
+      banner.style.opacity = '1';
+      banner.style.transform = 'translate(-50%, -50%) scale(1)';
+    }, 50);
 
     // Auto-hide after duration
     chrome.storage.sync.get(['duration'], function (result) {
       const duration = result.duration || 5000;
       setTimeout(() => {
         if (banner && banner.parentNode) {
-          banner.classList.remove('show');
+          banner.style.opacity = '0';
+          banner.style.transform = 'translate(-50%, -50%) scale(0.85)';
           setTimeout(() => {
+            isRemoved = true;
+            cancelFrame(frameId);
             if (banner.parentNode) {
               banner.remove();
             }
@@ -153,51 +284,8 @@ function createAndShowBanner(): boolean {
 
     return true;
   } catch (error) {
-    console.error('Image banner failed, creating fallback text banner', error);
-
-    // Create fallback text banner
-    const banner = document.createElement('div');
-    banner.className = 'elden-ring-merge-banner';
-    banner.innerHTML = `
-            <div class="elden-ring-banner-content">
-                <div class="elden-ring-text">
-                    <h1>MERGE ACCOMPLISHED</h1>
-                    <p>Test banner activated from extension popup</p>
-                </div>
-                <div class="elden-ring-close" onclick="this.parentElement.parentElement.remove()">×</div>
-            </div>
-        `;
-
-    document.body.appendChild(banner);
-
-    // Play sound effect if enabled
-    chrome.storage.sync.get(['soundEnabled', 'soundType'], function (soundResult) {
-      if (soundResult.soundEnabled !== false) {
-        const soundType = soundResult.soundType || 'you-die-sound';
-        const audio = new Audio(chrome.runtime.getURL(`assets/${soundType}.mp3`));
-        audio.volume = 1.0;
-        audio.play().catch((err) => console.log('Sound playback failed:', err));
-      }
-    });
-
-    setTimeout(() => banner.classList.add('show'), 50);
-
-    // Auto-hide after duration
-    chrome.storage.sync.get(['duration'], function (result) {
-      const duration = result.duration || 5000;
-      setTimeout(() => {
-        if (banner && banner.parentNode) {
-          banner.classList.remove('show');
-          setTimeout(() => {
-            if (banner.parentNode) {
-              banner.remove();
-            }
-          }, 500);
-        }
-      }, duration);
-    });
-
-    return true;
+    console.error('Canvas banner failed', error);
+    return false;
   }
 }
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -8,6 +8,8 @@ export interface EldenRingSettings {
   showOnPRApprove?: boolean;
   showOnPRClose?: boolean;
   soundType?: SoundType;
+  soundVolume?: number;
+  customBannerText?: string;
 }
 
 export type { SoundType };


### PR DESCRIPTION
## Summary
- Replace the static image banner with an animated canvas-drawn banner (glowing rune ring + pulsing title) for merge/create/approve/close events
- Add a "Custom Banner Text" popup setting so the displayed title can be overridden
- Add a "Sound Volume" slider (0–100%) so playback isn't hardcoded to full volume; value is clamped to [0,1] when applied

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `pnpm run type-check`
- [x] `pnpm test run` (46/46 passing, including new banner.test.ts cases for volume clamping and custom-text sanitization)
- [ ] Manually load the unpacked extension in Chrome and verify the popup slider updates playback volume and the banner shows custom text